### PR TITLE
Escape pipes in tags sent to datadog

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,10 @@ module.exports = function (options) {
   let base_url = options.base_url || false;
   let response_code = options.response_code || false;
 
+  function escapePipes(str) {
+    return str.replace(/\|/g, "\\|");
+  }
+
   return function (req, res, next) {
     if (!req._startTime) {
       req._startTime = new Date();
@@ -31,19 +35,19 @@ module.exports = function (options) {
       }
 
       let statTags = [
-        `route:${baseUrl}${req.route.path}`
+        escapePipes(`route:${baseUrl}${req.route.path}`)
       ].concat(dynamicTags);
 
       if (options.method) {
-        statTags.push(`method:${req.method.toLowerCase()}`);
+        statTags.push(escapePipes(`method:${req.method.toLowerCase()}`));
       }
 
       if (options.protocol && req.protocol) {
-        statTags.push(`protocol:${req.protocol}`);
+        statTags.push(escapePipes(`protocol:${req.protocol}`));
       }
 
       if (path !== false) {
-        statTags.push(`path:${baseUrl}${req.path}`);
+        statTags.push(escapePipes(`path:${baseUrl}${req.path}`));
       }
 
       if (response_code) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,9 +8,10 @@ module.exports = function (options) {
   let path = options.path || false;
   let base_url = options.base_url || false;
   let response_code = options.response_code || false;
+  const RE_PIPE = /\|/g;
 
   function escapePipes(str) {
-    return str.replace(/\|/g, "\\|");
+    return str && str.replace(RE_PIPE, "\\|");
   }
 
   return function (req, res, next) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@condenast/connect-datadog",
-	"version": "0.0.7",
+	"version": "0.0.8",
 	"description": "Datadog middleware for Connect JS / Express",
 	"main": "index.js",
 	"repository": {


### PR DESCRIPTION
datadog uses pipe characters ("|") to delimit different portions of information in log messages. Unescaped pipes in tag text can cause parsing errors (see https://github.com/AppPress/node-connect-datadog/issues/6)

Escape pipes using regular str.replace