### PR TITLE
Remove colons from express routes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,12 @@ module.exports = function (options) {
   let path = options.path || false;
   let base_url = options.base_url || false;
   let response_code = options.response_code || false;
+  const RE_COLON = /:/g;
   const RE_PIPE = /\|/g;
+
+  function escapeColons(str) {
+    return str && str.replace(RE_COLON, '');
+  }
 
   function escapePipes(str) {
     return str && str.replace(RE_PIPE, "\\|");
@@ -36,7 +41,7 @@ module.exports = function (options) {
       }
 
       let statTags = [
-        escapePipes(`route:${baseUrl}${req.route.path}`)
+        escapePipes(`route:${baseUrl}${escapeColons(req.route.path)}`)
       ].concat(dynamicTags);
 
       if (options.method) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ module.exports = function (options) {
   const RE_COLON = /:/g;
   const RE_PIPE = /\|/g;
 
-  function escapeColons(str) {
+  function removeColons(str) {
     return str && str.replace(RE_COLON, '');
   }
 
@@ -41,7 +41,7 @@ module.exports = function (options) {
       }
 
       let statTags = [
-        escapePipes(`route:${baseUrl}${escapeColons(req.route.path)}`)
+        escapePipes(`route:${baseUrl}${removeColons(req.route.path)}`)
       ].concat(dynamicTags);
 
       if (options.method) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@condenast/connect-datadog",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"description": "Datadog middleware for Connect JS / Express",
 	"main": "index.js",
 	"repository": {


### PR DESCRIPTION
After upgrading to version 0.0.8 we are still seeing parse errors in the datadog layer. Looks like the colons may also be a problem.

2017-11-17 15:17:39 UTC | ERROR | dd.dogstatsd | dogstatsd(dogstatsd.py:451) | Error receiving datagram `epi-web-services.node.express.response_time:110|h|#route:/api/content/v1/component/:contentType(article|gallery|package|recipe|curatedlist|menu),brand: epicurious,env: staging,response_code:200`
Traceback (most recent call last):
  File "/opt/datadog-agent/agent/dogstatsd.py", line 439, in start
    aggregator_submit(message)
  File "/opt/datadog-agent/agent/aggregator.py", line 617, in submit_packets
    parsed_packets = self.parse_metric_packet(packet)
  File "/opt/datadog-agent/agent/aggregator.py", line 489, in parse_metric_packet
    raise Exception(u'Metric value must be a number: %s, %s' % (name, raw_value))
Exception: Metric value must be a number: epi-web-services.node.express.response_time, contentType(article
