### PR TITLE
replace pipe and colon characters with unicode lookalikes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,10 +8,19 @@ module.exports = function (options) {
   let path = options.path || false;
   let base_url = options.base_url || false;
   let response_code = options.response_code || false;
+  const RE_COLON = /:/g;
   const RE_PIPE = /\|/g;
 
-  function escapePipes(str) {
-    return str && str.replace(RE_PIPE, "\\|");
+  // some unicode lookalikes that won't break datadog's "parser"
+  const FULL_WIDTH_BAR_CHAR = String.fromCodePoint(0xFF5C);
+  const TRIANGLE_COLON_CHAR = String.fromCodePoint(0x02d0);
+
+  function replacePipes(str) {
+    return str && str.replace(RE_PIPE, FULL_WIDTH_BAR_CHAR);
+  }
+
+  function replaceColons(str) {
+    return str && str.replace(RE_COLON, TRIANGLE_COLON_CHAR)
   }
 
   return function (req, res, next) {
@@ -36,19 +45,19 @@ module.exports = function (options) {
       }
 
       let statTags = [
-        escapePipes(`route:${baseUrl}${req.route.path}`)
+        replacePipes(`route:${baseUrl}${replaceColons(req.route.path)}`)
       ].concat(dynamicTags);
 
       if (options.method) {
-        statTags.push(escapePipes(`method:${req.method.toLowerCase()}`));
+        statTags.push(replacePipes(`method:${req.method.toLowerCase()}`));
       }
 
       if (options.protocol && req.protocol) {
-        statTags.push(escapePipes(`protocol:${req.protocol}`));
+        statTags.push(replacePipes(`protocol:${req.protocol}`));
       }
 
       if (path !== false) {
-        statTags.push(escapePipes(`path:${baseUrl}${req.path}`));
+        statTags.push(replacePipes(`path:${baseUrl}${req.path}`));
       }
 
       if (response_code) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,12 +15,8 @@ module.exports = function (options) {
   const FULL_WIDTH_BAR_CHAR = String.fromCodePoint(0xFF5C);
   const TRIANGLE_COLON_CHAR = String.fromCodePoint(0x02d0);
 
-  function replacePipes(str) {
-    return str && str.replace(RE_PIPE, FULL_WIDTH_BAR_CHAR);
-  }
-
-  function replaceColons(str) {
-    return str && str.replace(RE_COLON, TRIANGLE_COLON_CHAR)
+  function replaceDDCharacters(str) {
+    return str && str.replace(RE_PIPE, FULL_WIDTH_BAR_CHAR).replace(RE_COLON, TRIANGLE_COLON_CHAR);
   }
 
   return function (req, res, next) {
@@ -45,19 +41,19 @@ module.exports = function (options) {
       }
 
       let statTags = [
-        replacePipes(`route:${baseUrl}${replaceColons(req.route.path)}`)
+        `route:${baseUrl}${replaceDDCharacters(req.route.path)}`
       ].concat(dynamicTags);
 
       if (options.method) {
-        statTags.push(replacePipes(`method:${req.method.toLowerCase()}`));
+        statTags.push(`method:${req.method.toLowerCase()}`);
       }
 
       if (options.protocol && req.protocol) {
-        statTags.push(replacePipes(`protocol:${req.protocol}`));
+        statTags.push(`protocol:${req.protocol}`);
       }
 
       if (path !== false) {
-        statTags.push(replacePipes(`path:${baseUrl}${req.path}`));
+        statTags.push(`path:${baseUrl}${req.path}`);
       }
 
       if (response_code) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@condenast/connect-datadog",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"description": "Datadog middleware for Connect JS / Express",
 	"main": "index.js",
 	"repository": {


### PR DESCRIPTION
datadog uses pipes and colons as delimiters in its event serialization
format. in order to preserve human-readable routes in our events without
causing parse errors, we replace | and : with ｜ `(uFF5C)` and ː `(u02D0)`
respectively